### PR TITLE
Fix a flaky test by cleaning a polluted state.

### DIFF
--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -39,6 +39,7 @@ def cache_obj():
 
 
 def test_cached(cache_obj):
+    c.clear()
     for _ in range(10):
         cache_obj.test1(8, 0)
 


### PR DESCRIPTION
# What is the purpose of the change
This PR is to fix a flaky test  `tests/test_class.py::test_cached` which can fail after running `tests/test_class.py::test_timeout `, but passes when it is run in isolation.

# Reproduce the test failure
Run the following command:
```
python -m pytest tests/test_class.py::test_timeout tests/test_class.py::test_cached
```
# Expected Result
`tests/test_class.py::test_cached` should after running `tests/test_class.py::test_timeout `.

# Actual Result
```
>       assert len(c) == 1
E       assert 2 == 1
E        +  where 2 = len(<yamicache.yamicache.Cache object at 0x7fd40378b910>)
tests/test_class.py:45: AssertionError
```
# Why it fails
`Cache` is not cleaned before the `tests/test_class.py::test_cached`  is run.

# Fix 
Clean `Cache` at the beginning of `tests/test_class.py::test_cached` .